### PR TITLE
fix: 코스 난이도 조회 시, 식별자가 아닌 레벨 오름차순이 되게 조회

### DIFF
--- a/server/api/src/tests/integrations/course/test_list_course_difficulty.py
+++ b/server/api/src/tests/integrations/course/test_list_course_difficulty.py
@@ -20,4 +20,6 @@ def test_list_course_difficulty(client: TestClient, dbsession: Session):
 
     # then
     assert response.status_code == 200
-    assert len(response.json()) == 2
+    results = response.json()
+    assert len(results) == 2
+    assert [r["level"] for r in results] == [1, 2] # 레벨이 낮은 순대로 나열되어야 한다.

--- a/server/api/src/trailine_api/repositories/course_repositories.py
+++ b/server/api/src/trailine_api/repositories/course_repositories.py
@@ -63,7 +63,7 @@ class ICourseRepository(metaclass=ABCMeta):
 
 class CourseDifficultyRepository(ICourseDifficultyRepository):
     def get_course_difficulty_all(self, session: Session) -> Sequence[CourseDifficulty]:
-        stmt = select(CourseDifficulty)
+        stmt = select(CourseDifficulty).order_by(CourseDifficulty.level)
         return session.execute(stmt).scalars().all()
 
 


### PR DESCRIPTION

## 📝 주요 변경 내용 (Description)

* 코스 난이도 조회 API `GET /courses/difficulties` 호출 시, 식별자가 아닌 레벨 순(오름차순)으로 나열되게 수정

## 🔗 관련 이슈 (Related Issues)

- Closes: #91 
