### PR TITLE
feat: 일기예보 출처 추가

### DIFF
--- a/server/api/src/trailine_api/externals/datago.py
+++ b/server/api/src/trailine_api/externals/datago.py
@@ -45,6 +45,11 @@ class KmaMidForecastBase(DatagoAPI):
     하위 클래스에서 call()과 _parse_items()를 구현하여 사용한다.
     """
 
+    def get_published_at(self) -> datetime:
+        """현재 시각 기준 중기예보의 발표 시각을 datetime으로 반환한다."""
+        forecast_time_str = self._convert_time_to_forecast_time(datetime.now())
+        return datetime.strptime(forecast_time_str, "%Y%m%d%H%M")
+
     def _fetch_first_item(self, regional_code: str) -> Dict[str, Any]:
         """정상 응답 시, 실제 데이터 추출
         """
@@ -97,6 +102,10 @@ class IKmaMidLandForecastAPI(metaclass=ABCMeta):
     def call(self, regional_code: str) -> List[MidLandForecastItem]:
         pass
 
+    @abstractmethod
+    def get_published_at(self) -> datetime:
+        pass
+
 
 class IKmaMidLandTemperatureAPI(metaclass=ABCMeta):
     """중기 날씨 기온 예보
@@ -105,12 +114,20 @@ class IKmaMidLandTemperatureAPI(metaclass=ABCMeta):
     def call(self, regional_code: str) -> List[MidLandTemperatureItem]:
         pass
 
+    @abstractmethod
+    def get_published_at(self) -> datetime:
+        pass
+
 
 class IKmaShortForecastAPI(metaclass=ABCMeta):
     """단기 날씨 예보
     """
     @abstractmethod
     def call(self, nx: int, ny: int, days: int) -> List[ShortForecastItem]:
+        pass
+
+    @abstractmethod
+    def get_published_at(self) -> datetime:
         pass
 
 # ──────────────────────────────────────────
@@ -172,6 +189,11 @@ class KmaShortForecastAPI(DatagoAPI, IKmaShortForecastAPI):
 
     def __init__(self, service_key: str):
         super().__init__(service_key, "/1360000/VilageFcstInfoService_2.0/getVilageFcst")
+
+    def get_published_at(self) -> datetime:
+        """현재 시각 기준 단기예보의 발표 시각을 datetime으로 반환한다."""
+        base_date, base_time = self._convert_time_to_forecast_time(datetime.now())
+        return datetime.strptime(f"{base_date}{base_time}", "%Y%m%d%H%M")
 
     def call(self, nx: int, ny: int, days: int) -> List[ShortForecastItem]:
         if days > 4:

--- a/server/api/src/trailine_api/routers/v1/course.py
+++ b/server/api/src/trailine_api/routers/v1/course.py
@@ -145,9 +145,12 @@ async def get_course_weather_forecast(
     course_id: int = Path(..., description="코스 고유 아이디"),
     days: int = Query(3, ge=1, le=10, description="조회할 일기예보 일수 (최대 10일)"),
 ):
-    forecasts = await weather_service.get_forecasts(course_id, days)
+    published_at, forecasts = await weather_service.get_forecasts(course_id, days)
 
     return WeatherForecastResponseSchema(
+        source="기상청",
+        provider="공공데이터포털",
+        publishedAt=published_at,
         courseId=course_id,
         forecasts=forecasts,
     )

--- a/server/api/src/trailine_api/schemas/weather.py
+++ b/server/api/src/trailine_api/schemas/weather.py
@@ -26,6 +26,9 @@ class WeatherForecastItemSchema(BaseModel):
 
 
 class WeatherForecastResponseSchema(BaseModel):
+    source: str = Field(..., description="출처")
+    provider: str = Field(..., description="API 제공자")
+    published_at: datetime = Field(..., alias="publishedAt", description="발표 시각")
     course_id: int = Field(..., alias="courseId", description="코스 식별자")
     forecasts: List[WeatherForecastItemSchema] = Field(..., description="일기예보 리스트")
 

--- a/server/api/src/trailine_api/services/weather_services.py
+++ b/server/api/src/trailine_api/services/weather_services.py
@@ -17,7 +17,7 @@ from trailine_api.schemas.weather import DAY_OF_WEEK_KO_LIST, DAY_OF_WEEK_LIST, 
 
 
 MID_FORECAST_MIN_DAY = 5  # 기상청 중기예보 시작일 (5일 후부터)
-CACHE_TTL_SECONDS = 3600  # 1시간
+CACHE_TTL_SECONDS = 3600 * 3  # 1시간 + 3시간
 DATE_FORMAT = "%Y-%m-%d"
 
 
@@ -46,7 +46,9 @@ class IWeatherService(metaclass=ABCMeta):
         self._kma_short_forecast_api = kma_short_forecast_api
 
     @abstractmethod
-    async def get_forecasts(self, course_id: int, days: int) -> List[WeatherForecastItemSchema]:
+    async def get_forecasts(
+        self, course_id: int, days: int
+    ) -> Tuple[datetime, List[WeatherForecastItemSchema]]:
         """
         특정 위치/주소애 대한 장기 일기예보 정보를 가져오는 함수
         """
@@ -54,12 +56,17 @@ class IWeatherService(metaclass=ABCMeta):
 
 
 class WeatherService(IWeatherService):
-    async def get_forecasts(self, course_id: int, days: int) -> List[WeatherForecastItemSchema]:
-        # 캐싱된 데이터 가져오기
-        cache_key = f"weather:course:{course_id}:{days}"
+    async def get_forecasts(
+        self, course_id: int, days: int
+    ) -> Tuple[datetime, List[WeatherForecastItemSchema]]:
+        # 발표 시각 계산 (네트워크 호출 없이 시간 계산만 수행)
+        published_at = self._resolve_published_at(days)
+
+        # 캐싱된 데이터 가져오기 (발표 시각이 바뀌면 키도 자연스럽게 무효화)
+        cache_key = f"weather:course:{course_id}:{days}:{published_at.strftime('%Y%m%d%H%M')}"
         cached = await self._cache.get_json(cache_key)
         if isinstance(cached, list):
-            return [WeatherForecastItemSchema(**item) for item in cached]
+            return published_at, [WeatherForecastItemSchema(**item) for item in cached]
 
         # 캐싱된 데이터 없으면 직접 조회
         status_code, temp_code, nx, ny = self._get_course_weather_info(course_id)
@@ -80,7 +87,20 @@ class WeatherService(IWeatherService):
             ttl_seconds=CACHE_TTL_SECONDS,
         )
 
-        return results
+        return published_at, results
+
+    def _resolve_published_at(self, days: int) -> datetime:
+        """요청 days에 따라 사용된 예보 API의 발표 시각을 결정한다.
+
+        days < 5인 경우는 단기예보만 사용하므로 단기예보 발표 시각을 그대로 사용하고,
+        days >= 5인 경우 단기/중기 발표 시각 중 가장 최근 시각을 사용한다.
+        """
+        short_published_at = self._kma_short_forecast_api.get_published_at()
+        if days < MID_FORECAST_MIN_DAY:
+            return short_published_at
+
+        mid_published_at = self._kma_mid_forecast_api.get_published_at()
+        return max(short_published_at, mid_published_at)
 
     def _get_course_weather_info(self, course_id: int) -> Tuple[str, str, int, int]:
         """DB에서 기상청 코드와 좌표를 조회한다."""

--- a/web/src/components/client/WeatherForecast.tsx
+++ b/web/src/components/client/WeatherForecast.tsx
@@ -54,8 +54,18 @@ const formatDate = (dateStr: string): string => {
     return `${parseInt(month)}/${parseInt(day)}`;
 };
 
+const formatPublishedAt = (isoString: string): string => {
+    const date = new Date(isoString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    return `${year}.${month}.${day} ${hours}:${minutes}`;
+};
+
 const WeatherForecast: React.FC<Props> = ({ courseId }: Props) => {
-    const [forecasts, setForecasts] = useState<Forecast[]>([]);
+    const [forecastData, setForecastData] = useState<WeatherForecastResponse | null>(null);
     const [loading, setLoading] = useState<boolean>(true);
     const [error, setError] = useState<boolean>(false);
 
@@ -69,7 +79,7 @@ const WeatherForecast: React.FC<Props> = ({ courseId }: Props) => {
                 return res.json();
             })
             .then((data: WeatherForecastResponse) => {
-                setForecasts(data.forecasts);
+                setForecastData(data);
             })
             .catch(() => {
                 setError(true);
@@ -90,7 +100,9 @@ const WeatherForecast: React.FC<Props> = ({ courseId }: Props) => {
         );
     }
 
-    if (error || forecasts.length === 0) return null;
+    if (error || forecastData === null || forecastData.forecasts.length === 0) return null;
+
+    const { forecasts, source, provider, publishedAt } = forecastData;
 
     return (
         <div className="my-6">
@@ -145,6 +157,11 @@ const WeatherForecast: React.FC<Props> = ({ courseId }: Props) => {
                     );
                 })}
             </div>
+
+            {/* 출처 / 제공자 / 발표시각 */}
+            <p className="text-xs text-base-content/40 mt-2 text-right">
+                출처: {source} · 제공: {provider} · 발표: {formatPublishedAt(publishedAt)}
+            </p>
         </div>
     );
 };

--- a/web/src/types/responses/weather-forecast.ts
+++ b/web/src/types/responses/weather-forecast.ts
@@ -11,6 +11,9 @@ export interface Forecast {
 }
 
 export interface WeatherForecastResponse {
+    source: string;
+    provider: string;
+    publishedAt: string;
     courseId: number;
     forecasts: Forecast[];
 }


### PR DESCRIPTION
## 📝 주요 변경 내용 (Description)

### API Server
                                                                                                                      
**`externals/datago.py`**                                                                                                     

  - `IKmaShortForecastAPI`, `IKmaMidLandForecastAPI`, `IKmaMidLandTemperatureAPI` 세 인터페이스에 `get_published_at() -> datetime`
   추상 메서드 추가
  - `KmaMidForecastBase.get_published_at()` 구현 → 두 중기예보 구현체(`KmaMidLandForecastAPI`, `KmaMidLandTemperatureAPI`)가      
  상속으로 자동 만족                                                                                                              
  - `KmaShortForecastAPI.get_published_at()` 구현
  - 기존 `_convert_time_to_forecast_time()` 시간 계산 로직을 그대로 재사용해 중복 없음                                            
                                                                                                                                  
**`services/weather_services.py`**
                                                                                                                                  
  - `get_forecasts()` 반환 타입 변경                                                                                              
    - **변경 전**: `List[WeatherForecastItemSchema]`
    - **변경 후**: `Tuple[datetime, List[WeatherForecastItemSchema]]`                                                             
  - 발표 시각 결정 로직을 `_resolve_published_at()`로 분리                                                                      
    - `days < 5`: 중기예보를 사용하지 않으므로 **단기예보 발표 시각을 그대로 사용** (`max` 미적용)                                
    - `days >= 5`: 단기/중기 발표 시각 중 가장 최근(`max`) 시각 사용                                                              
  - 캐시 키 변경                                                                                                                  
    - **변경 전**: `weather:course:{course_id}:{days}`                                                                            
    - **변경 후**: `weather:course:{course_id}:{days}:{YYYYMMDDHHMM}`                                                           
    - 발표 시각이 갱신되면 키가 자연스럽게 바뀌어 stale 데이터 방지                                                               
    - `get_published_at()`은 네트워크 호출 없는 시간 계산이라 캐시 lookup 전 호출에도 추가 비용 없음                            
                                                                                                                                  
**`routers/v1/course.py`**                                                                                                      
                                                                                                                                  
  - 서비스 반환값을 `published_at, forecasts`로 언팩하고 응답 스키마에 `publishedAt` 전달                                         
                                                                                                                                
**설계 메모**                                                                                                                    
   
  - 외부 API 클래스가 이미 가지고 있던 `_convert_time_to_forecast_time()` 로직을 그대로 활용해 시간 계산 로직 중복 없음           
  - 인터페이스/서비스/라우터/스키마 어디도 구조적 변경 없이 메서드 1개와 반환 타입만 추가/조정하는 최소 침습 방식으로 구현 

### Frontend

**Summary**
- 주간 일기예보 API 응답에 추가된 `source`, `provider`, `publishedAt` 필드를 웹 UI에 반영
- 일기예보 카드 리스트 하단에 "출처 · 제공 · 발표시각" 정보를 한 줄로 표시하여 데이터 신뢰성 확보

**Changes**
- `src/types/responses/weather-forecast.ts`: `WeatherForecastResponse` 타입에 `source`, `provider`, `publishedAt` 필드 추가
- `src/components/client/WeatherForecast.tsx`:
  - state를 `forecasts: Forecast[]`에서 전체 응답 객체(`WeatherForecastResponse | null`)로 변경하여 메타데이터까지 함께 보존
  - `formatPublishedAt` 헬퍼 추가 — ISO 문자열을 `YYYY.MM.DD HH:MM` 형식으로 변환
  - 카드 리스트 하단에 출처/제공자/발표시각을 우측 정렬로 추가 (`text-xs text-base-content/40`로 가독성을 해치지 않는 보조 정보 처리)

**UI**
```
[월 4/12] [화 4/13] [수 4/14] [목 4/15] [금 4/16] [토 4/17] [일 4/18]
                          출처: 기상청 · 제공: 공공데이터포털 · 발표: 2026.04.11 11:54
```


## 🔗 관련 이슈 (Related Issues)

- Closes: #139 
